### PR TITLE
fix: migrate from deprecated tool.uv.dev-dependencies to dependency-groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,8 @@ dependencies = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pytest>=8.0.0",
     "pytest-order>=1.3.0",
     "ruff>=0.11.0",


### PR DESCRIPTION
## Summary
- Replace deprecated `[tool.uv]` dev-dependencies with `[dependency-groups]` dev format
- Fixes pytest warning about deprecated configuration

## Test plan
- [x] `uv sync` completes without deprecation warning
- [x] All unit tests pass (`pytest -v -s -m unit tests/`)
- [x] `ruff check .` passes
- [x] `mypy blabot/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)