### PR TITLE
fix: ignore CPY001 copyright header rule in ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ target-version = "py312"
 select = ["ALL"]
 ignore = [
     "COM812",   # trailing comma conflicts with formatter
+    "CPY",      # this project does not use copyright header comments
     "D203",     # 1 blank line required before class docstring (conflicts with D211)
     "D213",     # multi-line docstring summary should start at the second line (conflicts with D212)
 ]


### PR DESCRIPTION
## Summary
- `uv run ruff check .` was failing with 24 CPY001 errors because ruff's `select = ["ALL"]` enables the copyright-header rule, and this project doesn't maintain copyright headers.
- Added `CPY` to the ignore list in `pyproject.toml`.

## Test plan
- [x] `uv run ruff check .` passes
- [x] `uv run pytest -v -s` — 31 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)