### PR TITLE
chore: group minor/patch dependency updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
     labels:
       - "dependencies"
     open-pull-requests-limit: 5
+    groups:
+      pip-patch-minor:
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -21,3 +26,8 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    groups:
+      github-actions-patch-minor:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
- Group minor/patch updates per ecosystem (pip, github-actions) into a single PR to reduce merge overhead from frequent version bumps
- Major version updates remain ungrouped so breaking changes stay easy to review individually

## Test plan
- N/A (Dependabot config change; verified YAML structure matches Dependabot's documented `groups`/`update-types` schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)