### PR TITLE
chore: register all custom pytest markers and enable --strict-markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,16 @@ dev = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = "--strict-markers"
 markers = [
     "unit: Unit tests for individual classes and methods",
+    "simple_process_test: Tests using ProcessIO against a local example app",
+    "device_test: Tests using DeviceIO against a virtual serial device (requires socat)",
+    "ssh_test: Tests using SSHProcessIO against a remote host (requires REMOTE_USER_NAME/REMOTE_HOST_NAME/REMOTE_KEY_PATH)",
+    "docker_test: Tests using DockerRunIO/DockerExecIO from the host",
+    "docker_inner_test: Tests run from inside a Docker container",
+    "easy: Simple/fast test scenarios",
+    "hard: Complex/slow test scenarios",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary
- Registered previously-unregistered pytest markers used in `tests/` and `examples/tests/`: `simple_process_test`, `device_test`, `ssh_test`, `docker_test`, `docker_inner_test`, `easy`, `hard` (only `unit` was registered before)
- Enabled `--strict-markers` so a typo'd `@pytest.mark.*` fails at collection time instead of only emitting a warning

## Test plan
- [x] `uv run pytest --collect-only -q` (tests/) — 31 tests collected, no errors
- [x] `uv run pytest --collect-only -q examples/tests/` — 9 tests collected, no errors
- [x] `uv run ruff check .` / `uv run ruff format --check .`
- [x] `uv run mypy blabot/`